### PR TITLE
Python Versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: checkout

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ docs_require = ['optax', 'matplotlib', 'jupyter', 'jupyterlab', 'tqdm',
 
 
 setuptools.setup(
-    python_requires='>=3.8, <4',
+    python_requires='>=3.9, <4',
     name="zodiax",
     version=find_version("zodiax", "__init__.py"),
     description="Equinox extension for scientific programming",

--- a/zodiax/__init__.py
+++ b/zodiax/__init__.py
@@ -1,5 +1,5 @@
 name = "zodiax"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 # Import as modules
 from . import base


### PR DESCRIPTION
Zodiax is no longer compatible with Python 3.8 as `optax` requires Python>=3.9.

Also, trying to add testing for 3.12.