### PR TITLE
fix invalid escape sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 
 [tool.coverage.run]
 source = ["zodiax"]

--- a/src/zodiax/stats.py
+++ b/src/zodiax/stats.py
@@ -20,7 +20,7 @@ __all__ = [
 
 
 def z_score(x: Array, mean: Array, std: Array) -> Array:
-    """
+    r"""
     Calculates the z-score $(\mu - x) / \sigma$ of a value given a mean and standard
     deviation.
 
@@ -42,7 +42,7 @@ def z_score(x: Array, mean: Array, std: Array) -> Array:
 
 
 def mv_z_score(x: Array, mean: Array, cov: Array) -> Array:
-    """
+    r"""
     Calculates the squared Mahalanobis distance $(\mu - x)^\top\Sigma^{-1}(\mu - x)$
     of a value given a mean and covariance matrix.
 


### PR DESCRIPTION
There are a few dosctrings the have invalid escape sequences, which cause `SyntaxWarnings` in Python > 3.12, and `DeprecationWarnings` in 3.10 and 3.11.

I use `filterwarnings = ["error"]` in my tests on a downstream project, so these warnings cause test failures. 

To reproduce, 

```bash
uv run --python 3.12 --with zodiax==0.5.0 python -W error -c "import zodiax"
```

which results in a `SyntaxError`. After the fixes, all tests should pass with `filterwarnings = ["error"]` turned on:

```bash
uv run --python 3.12 --with zodiax@. python -W error -c "import zodiax"

# Test 3.10-3.14
for ver in 3.10 3.11 3.12 3.14; do
    uv run --python $ver --extra tests pytest -W error
done
```


